### PR TITLE
chore: add generated files to phpstan analyse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "require-dev": {
         "buildotter/php-core": "dev-main",
+        "fakerphp/faker": "^1.24",
         "phpstan/phpstan": "^1.11",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6d5aa26e581762e259119261edeaaff",
+    "content-hash": "073b0017b94abbc6b457e9faeccd1ace",
     "packages": [
         {
             "name": "jetbrains/phpstorm-stubs",
@@ -1154,12 +1154,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/buildotter/php-core.git",
-                "reference": "830d9ac152aaa61fe927b21062d39c91cfbff1bd"
+                "reference": "aa90d424a0b0aeaa3c36a72786b328d68f7b94e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/buildotter/php-core/zipball/830d9ac152aaa61fe927b21062d39c91cfbff1bd",
-                "reference": "830d9ac152aaa61fe927b21062d39c91cfbff1bd",
+                "url": "https://api.github.com/repos/buildotter/php-core/zipball/aa90d424a0b0aeaa3c36a72786b328d68f7b94e6",
+                "reference": "aa90d424a0b0aeaa3c36a72786b328d68f7b94e6",
                 "shasum": ""
             },
             "require": {
@@ -1167,8 +1167,10 @@
             },
             "require-dev": {
                 "fakerphp/faker": "^1.23",
-                "phpstan/phpstan": "^1.11",
-                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
                 "symfony/var-dumper": "^6.4"
             },
             "suggest": {
@@ -1203,9 +1205,72 @@
             ],
             "support": {
                 "issues": "https://github.com/buildotter/php-core/issues",
-                "source": "https://github.com/buildotter/php-core/tree/main"
+                "source": "https://github.com/buildotter/php-core/tree/0.3.0"
             },
-            "time": "2024-09-29T14:11:30+00:00"
+            "time": "2025-06-30T07:48:58+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -1510,9 +1575,9 @@
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -10,6 +10,9 @@ parameters:
 	level: max
 	bootstrapFiles:
 		- ./tools/phpunit.phar
+	fileExtensions:
+		- php
+		- php.txt
 	paths:
 		- src/
 		- tests/
@@ -18,3 +21,8 @@ parameters:
 		- e2e/cases/*
 	symfony:
 		consoleApplicationLoader: tests/console-app.php
+	ignoreErrors:
+		# Generated `\Buildotter\Core\Buildatable::new` methods must be completed by the user.
+		-
+			message: "#^Class Buildotter\\\\Tests\\\\MakerStandalone\\\\fixtures\\\\expected\\\\[a-zA-Z0-9\\_]+Builder constructor invoked with 0 parameters, [0-9]+ required\\.$#"
+			path: tests/fixtures/expected/*.php.txt


### PR DESCRIPTION
# What does it do
Analyse generated files in tests to be sure that it generate valide code

# Why ?

Generated file are not analysed by phpstan. If it generate a code with errors we will not know it.

see https://github.com/buildotter/php-core/issues/53

# How ?
By adding the excepted `*.php.txt` files  in phpstan analyse, it will add excepted generated files for the test to the analyse et we can detect errors like this. It's a proposition of a simple solution to do this. But with this config, we will analyse all file with `php.txt` extension and we may have files we don't wont analyse inside. Maybe it will be better to rename this files `php.gen.txt` to separe generate text php file from the other ?

