### PR TITLE
chore: bump roave/better-reflection from 6.60.0 to 6.70.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.4",
         "nette/php-generator": "^4.1",
-        "roave/better-reflection": "^6.25",
+        "roave/better-reflection": "^6.70",
         "symfony/console": "^6.4",
         "symfony/filesystem": "^6.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6844e54276bd30f98fa841e6f5e051e1",
+    "content-hash": "1f81cdc3f9c50a95f3d86a1c884dccf0",
     "packages": [
         {
             "name": "jetbrains/phpstorm-stubs",
-            "version": "v2024.3",
+            "version": "v2025.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "0e82bdfe850c71857ee4ee3501ed82a9fc5d043c"
+                "url": "https://github.com/JetBrains/phpstorm-stubs",
+                "reference": "d1ee5e570343bd4276a3d5959e6e1c2530b006d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/0e82bdfe850c71857ee4ee3501ed82a9fc5d043c",
-                "reference": "0e82bdfe850c71857ee4ee3501ed82a9fc5d043c",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/d1ee5e570343bd4276a3d5959e6e1c2530b006d0",
+                "reference": "d1ee5e570343bd4276a3d5959e6e1c2530b006d0",
                 "shasum": ""
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "v3.64.0",
-                "nikic/php-parser": "v5.3.1",
-                "phpdocumentor/reflection-docblock": "5.6.0",
-                "phpunit/phpunit": "11.4.3"
+                "friendsofphp/php-cs-fixer": "^v3.86",
+                "nikic/php-parser": "^v5.6",
+                "phpdocumentor/reflection-docblock": "^5.6",
+                "phpunit/phpunit": "^12.3"
             },
             "type": "library",
             "autoload": {
@@ -48,10 +48,7 @@
                 "stubs",
                 "type"
             ],
-            "support": {
-                "source": "https://github.com/JetBrains/phpstorm-stubs/tree/v2024.3"
-            },
-            "time": "2024-12-14T08:03:12+00:00"
+            "time": "2025-09-18T15:47:24+00:00"
         },
         {
             "name": "nette/php-generator",
@@ -220,16 +217,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -272,9 +269,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "psr/container",
@@ -331,30 +328,30 @@
         },
         {
             "name": "roave/better-reflection",
-            "version": "6.60.0",
+            "version": "6.70.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/BetterReflection.git",
-                "reference": "53dd01710b5c705b1b570a1820bd65e70529ebc7"
+                "reference": "73df862c931946cf677eddc1cca176e3bb6a1d34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/BetterReflection/zipball/53dd01710b5c705b1b570a1820bd65e70529ebc7",
-                "reference": "53dd01710b5c705b1b570a1820bd65e70529ebc7",
+                "url": "https://api.github.com/repos/Roave/BetterReflection/zipball/73df862c931946cf677eddc1cca176e3bb6a1d34",
+                "reference": "73df862c931946cf677eddc1cca176e3bb6a1d34",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "2024.3",
-                "nikic/php-parser": "^5.6.0",
-                "php": "~8.2.0 || ~8.3.2 || ~8.4.1 || ~8.5.0"
+                "jetbrains/phpstorm-stubs": "2025.3",
+                "nikic/php-parser": "^5.7.0",
+                "php": "~8.4.1 || ~8.5.0"
             },
             "conflict": {
                 "thecodingmachine/safe": "<1.1.3"
             },
             "require-dev": {
-                "phpbench/phpbench": "^1.4.1",
-                "phpunit/phpunit": "^11.5.28"
+                "phpbench/phpbench": "^1.6.1",
+                "phpunit/phpunit": "^13.1.0"
             },
             "suggest": {
                 "composer/composer": "Required to use the ComposerSourceLocator"
@@ -394,9 +391,9 @@
             "description": "Better Reflection - an improved code reflection API",
             "support": {
                 "issues": "https://github.com/Roave/BetterReflection/issues",
-                "source": "https://github.com/Roave/BetterReflection/tree/6.60.0"
+                "source": "https://github.com/Roave/BetterReflection/tree/6.70.0"
             },
-            "time": "2025-08-21T11:08:59+00:00"
+            "time": "2026-04-07T18:16:42+00:00"
         },
         {
             "name": "symfony/console",
@@ -1150,12 +1147,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/buildotter/php-core.git",
-                "reference": "35d663a796c67a6926cbd94df91a8fc1ec274b2b"
+                "reference": "d800b9f3f197cddf1b321e3ca00ec887fbc804be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/buildotter/php-core/zipball/35d663a796c67a6926cbd94df91a8fc1ec274b2b",
-                "reference": "35d663a796c67a6926cbd94df91a8fc1ec274b2b",
+                "url": "https://api.github.com/repos/buildotter/php-core/zipball/d800b9f3f197cddf1b321e3ca00ec887fbc804be",
+                "reference": "d800b9f3f197cddf1b321e3ca00ec887fbc804be",
                 "shasum": ""
             },
             "require": {
@@ -1203,7 +1200,7 @@
                 "issues": "https://github.com/buildotter/php-core/issues",
                 "source": "https://github.com/buildotter/php-core/tree/main"
             },
-            "time": "2025-08-30T10:27:28+00:00"
+            "time": "2026-04-04T16:47:31+00:00"
         },
         {
             "name": "fakerphp/faker",


### PR DESCRIPTION
  - Upgrading jetbrains/phpstorm-stubs (v2024.3 => v2025.3)
  - Upgrading nikic/php-parser (v5.6.1 => v5.7.0)
  - Upgrading roave/better-reflection (6.66.0 => 6.70.0)